### PR TITLE
bugfix: at function Rank\Adapter\Redis::getRankByKey: use operator '=…

### DIFF
--- a/ZPHP/Rank/Adapter/Redis.php
+++ b/ZPHP/Rank/Adapter/Redis.php
@@ -70,7 +70,7 @@ class Redis implements IRank
             $rank = $this->redis->zRank($rankType, $key);
         }
 
-        if(false == $rank) {
+        if(false === $rank) {
             return 0;
         }
         return ++$rank;


### PR DESCRIPTION
Rank\Adapter\Redis::getRankByKey函数中，检查返回结果是否是false需要使用===，否则rank=1时会返回0，而rank=n (n>2)时返回n